### PR TITLE
add testMode & update mongoose connect options

### DIFF
--- a/lib/phobos.js
+++ b/lib/phobos.js
@@ -15,7 +15,8 @@ class Phobos {
       bearerTokenExpiry: '180d',
       dbUri: 'mongodb://localhost/phobos',
       scopeCarrier: { model: 'User', field: 'scope', availableScopes: [ '*', 'user', 'owner', 'admin' ] },
-      errorHandler: false
+      errorHandler: false,
+      testMode: false,
     };
 
     for (let p in options) {
@@ -42,6 +43,7 @@ class Phobos {
       this._options.bearerTokenExpiry
     );
 
+    this.testMode = this._options.testMode
     return this;
   }
 
@@ -77,30 +79,32 @@ class Phobos {
 
   // Initializes the Phobos.DS object and returns it - useful for task runners
   initDb() {
-    if (this._databaseInitFlag) return this.DS;
+    if (!this.testMode) {
+      if (this._databaseInitFlag) return this.DS;
 
-    const gracefulExit = () => {
-      this.database.connection.close(() => {
-        console.log('=> MongoDB connection closed through SIGTERM');
+      const gracefulExit = () => {
+        this.database.connection.close(() => {
+          console.log('=> MongoDB connection closed through SIGTERM');
+          process.exit(0);
+        });
+      };
+  
+      const options = { server: {}, useMongoClient: true };
+  
+      process.on('SIGINT', gracefulExit).on('SIGTERM', gracefulExit);
+  
+      mongoose.connection.on('error', (err) => {
+        console.error('!! Failed to connect to MongoDB', err);
         process.exit(0);
       });
-    };
+  
+      mongoose.connection.on('disconnected', () => {
+        console.log('=> MongoDB connection disconnected');
+        process.exit(0);
+      });
+    }
 
-    const options = { server: {}, useMongoClient: true };
-
-    process.on('SIGINT', gracefulExit).on('SIGTERM', gracefulExit);
-
-    mongoose.connection.on('error', (err) => {
-      console.error('!! Failed to connect to MongoDB', err);
-      process.exit(0);
-    });
-
-    mongoose.connection.on('disconnected', () => {
-      console.log('=> MongoDB connection disconnected');
-      process.exit(0);
-    });
-
-    this.database.connect(this._options.dbUri);
+    this.database.connect(this._options.dbUri, { useNewUrlParser: true });
     this.DS = {};
 
     const Schemas = (typeof this.schema === 'function') ? this.schema(this.database) : {};
@@ -166,9 +170,11 @@ class Phobos {
 
     this._router.mount();
 
-    this.server.listen(options.port, () => {
-      console.log(`=> ${options.appName} server running on port ${options.port}`);
-    });
+    if (!this.testMode) {
+      this.server.listen(options.port, () => {
+        console.log(`=> ${options.appName} server running on port ${options.port}`);
+      });
+    }
 
     return this;
   }

--- a/lib/phobos.js
+++ b/lib/phobos.js
@@ -104,7 +104,12 @@ class Phobos {
       });
     }
 
-    this.database.connect(this._options.dbUri, { useNewUrlParser: true });
+    const connectOptions = {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+      useCreateIndex: true,
+    }
+    this.database.connect(this._options.dbUri, connectOptions);
     this.DS = {};
 
     const Schemas = (typeof this.schema === 'function') ? this.schema(this.database) : {};


### PR DESCRIPTION
I added a `this.testMode` variable to enable testing with `supertest`
If in `testMode`, two parts of`lib/phobos.js` are not executed:
- in `initDb`, the code handling mongoose disconnection events are skipped
- in `start`, the express server is not started.

